### PR TITLE
Temporarily add "notable forks" from ERB wiki to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,31 @@
 | 1.|  [sqlite](https://github.com/electron-react-boilerplate/examples/tree/master/examples/sqlite) | Bundling and using SQLite with ERB |
 | 2.|  [typescript](https://github.com/electron-react-boilerplate/examples/tree/master/examples/typescript) | Type checking with TS with React support |
 
+## Notable Forks
+
+Mobx
+* [electron-react-mobx-boilerplate](https://github.com/gzgogo/electron-react-mobx-boilerplate)
+
+TypeScript
+* [erb-typescript-example](https://github.com/amilajack/erb-typescript-example)
+* [electron-react-typescript-boilerplate](https://github.com/ManuKle/electron-react-typescript-boilerplate)
+
+CSS
+* [Ant Design example](https://github.com/amilajack/erb-ant-design-example)
+* [Bootstrap example](https://github.com/amilajack/erb-bootstrap-example)
+
+Native Modules Example
+* [sqlite example](https://github.com/amilajack/erb-sqlite-example)
+* [serialport example](https://github.com/amilajack/erb-serialport-example)
+
+Miscellaneous Example
+* [express example](https://github.com/amilajack/erb-express-example)
+* [monorepo example](https://github.com/amilajack/erb-monorepo-example)
+* [package in yarn workspaces example](https://github.com/vikr01/erb-with-workspaces-example)
+* [html video example](https://github.com/amilajack/erb-video-example)
+* [importing audio files example](https://github.com/amilajack/erb-audio-example)
+* [reading local files at runtime in dev and prod env](https://github.com/amilajack/erb-local-fs-read-example)
+
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@
 Mobx
 * [electron-react-mobx-boilerplate](https://github.com/gzgogo/electron-react-mobx-boilerplate)
 
-TypeScript
-* [erb-typescript-example](https://github.com/amilajack/erb-typescript-example)
-* [electron-react-typescript-boilerplate](https://github.com/ManuKle/electron-react-typescript-boilerplate)
-
 CSS
 * [Ant Design example](https://github.com/amilajack/erb-ant-design-example)
 * [Bootstrap example](https://github.com/amilajack/erb-bootstrap-example)


### PR DESCRIPTION
Ideally, all these examples would be migrated to be in-repo examples